### PR TITLE
feat: refactor theme file to make custom theming easier

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -8,20 +8,12 @@ const config: Config = {
     "./components/**/*.{js,ts,jsx,tsx,mdx}",
     "./app/**/*.{js,ts,jsx,tsx,mdx}",
   ],
-  darkMode: theme.darkMode as Config["darkMode"],
   safelist: [
     {
       pattern: /bg-(red|green|yellow)-(500|600)/,
     },
   ],
-  theme: {
-    extend: {
-      colors: {
-        white: theme.white,
-        black: theme.black,
-        primary: theme.primary,
-      },
-    },
-  },
+  darkMode: theme.darkMode as Config["darkMode"],
+  theme: theme.theme,
 };
 export default config;

--- a/theme.ts.example
+++ b/theme.ts.example
@@ -1,8 +1,14 @@
-const colors = require('tailwindcss/colors');
+const colors = require("tailwindcss/colors");
 
 export default {
-    darkMode: 'selector',
-    black: '#000000',
-    white: '#ffffff',
-    primary: colors.fuchsia,
-}
+  darkMode: "selector",
+  theme: {
+    extend: {
+      colors: {
+        black: "#000000",
+        white: "#ffffff",
+        primary: colors.fuchsia,
+      },
+    },
+  },
+};


### PR DESCRIPTION
Update the theme file so it exports the entire Tailwind `theme` object. This will make it easier to drop in a custom theme if a vendor has one.