### PR TITLE
fix: missing share metadata

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -19,6 +19,25 @@ export async function generateMetadata(): Promise<Metadata> {
       icon: metadata.favicon_url,
       shortcut: metadata.favicon_url,
     },
+    openGraph: {
+      title: metadata.name,
+      description: metadata.description,
+      type: "website",
+      images: [
+        {
+          url: metadata.logo_url,
+        },
+      ],
+    },
+    twitter: {
+      title: metadata.name,
+      description: metadata.description,
+      images: [
+        {
+          url: metadata.logo_url,
+        },
+      ],
+    },
   };
 }
 


### PR DESCRIPTION
Add in opengraph and twitter metadata fields so we don't have empty share widgets.

We may want to add extra fields to set images specifically for sharing. That would look better.