### PR TITLE
fix: default status to yellow

### DIFF
--- a/components/Install.tsx
+++ b/components/Install.tsx
@@ -161,12 +161,12 @@ const Status: FC<{ status: string; status_description: string }> = ({
   status,
   status_description,
 }) => {
-  const clr =
-    status === "provisioning"
-      ? "yellow-500"
-      : status === "active"
-        ? "green-600"
-        : "red-500";
+  let clr = "yellow-500";
+  if (status === "active") {
+    clr = "green-600";
+  } else if (status === "error") {
+    clr = "red-500";
+  }
 
   return (
     <span className="text-sm">


### PR DESCRIPTION
Default to yellow color for status page, until we get either a definitive "active" or "error" status.