### PR TITLE
fix: rendered markdown is correctly styled

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,12 +1,11 @@
 import type { Metadata } from "next";
 import { Inter } from "next/font/google";
 import React from "react";
-import showdown from "showdown";
 import { getInstaller } from "@/common";
 import { Link, PoweredByNuon } from "@/components";
+import { Markdown } from "@/components/Markdown";
 import "./globals.css";
 
-const markdown = new showdown.Converter();
 const inter = Inter({ subsets: ["latin"] });
 
 export async function generateMetadata(): Promise<Metadata> {
@@ -63,11 +62,7 @@ export default async function RootLayout({
           <footer className="flex items-center justify-between">
             <div className="flex gap-2 items-center">
               {metadata.copyright_markdown ? (
-                <div
-                  dangerouslySetInnerHTML={{
-                    __html: markdown.makeHtml(metadata.copyright_markdown),
-                  }}
-                />
+                <Markdown content={metadata.copyright_markdown} />
               ) : (
                 <>
                   <span className="text-xs">
@@ -86,11 +81,7 @@ export default async function RootLayout({
             </div>
             <div className="flex gap-6 items-center">
               {metadata.footer_markdown ? (
-                <div
-                  dangerouslySetInnerHTML={{
-                    __html: markdown.makeHtml(metadata.footer_markdown),
-                  }}
-                />
+                <Markdown content={metadata.footer_markdown} />
               ) : (
                 <PoweredByNuon />
               )}

--- a/components/InstallStepper/InstallStatusContent/index.tsx
+++ b/components/InstallStepper/InstallStatusContent/index.tsx
@@ -3,12 +3,10 @@ import {
   AccordionHeader,
   AccordionBody,
 } from "@material-tailwind/react";
-import showdown from "showdown";
 import { InstallStatus } from "./InstallStatus";
 import { StatusIcon } from "@/components";
 import { InstallButton } from "./InstallButton";
-
-const markdown = new showdown.Converter();
+import { Markdown } from "@/components/Markdown";
 
 export const InstallStatusContent = ({
   open = false,
@@ -31,11 +29,7 @@ export const InstallStatusContent = ({
     <AccordionBody>
       <div className="grid grid-cols-2 gap-2">
         <div>
-          <div
-            dangerouslySetInnerHTML={{
-              __html: markdown.makeHtml(post_install_markdown),
-            }}
-          />
+          <Markdown content={post_install_markdown} />
         </div>
 
         <div>

--- a/components/Markdown.tsx
+++ b/components/Markdown.tsx
@@ -1,0 +1,11 @@
+import showdown from "showdown";
+const markdown = new showdown.Converter();
+
+export const Markdown = ({ content = "" }) => (
+  <div
+    className="prose"
+    dangerouslySetInnerHTML={{
+      __html: markdown.makeHtml(content),
+    }}
+  />
+);

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "showdown": "^2.1.0"
       },
       "devDependencies": {
+        "@tailwindcss/typography": "^0.5.13",
         "@types/node": "^20",
         "@types/react": "18.2.42",
         "@types/react-dom": "^18",
@@ -628,6 +629,34 @@
       "integrity": "sha512-E4KcWTpoLHqwPHLxidpOqQbcrZVgi0rsmmZXUle1jXmJfuIf/UWpczUJ7MZZ5tlxytgJXyp0w4PGkkeLiuIdZw==",
       "dependencies": {
         "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@tailwindcss/typography": {
+      "version": "0.5.13",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.13.tgz",
+      "integrity": "sha512-ADGcJ8dX21dVVHIwTRgzrcunY6YY9uSlAHHGVKvkA+vLc5qLwEszvKts40lx7z0qc4clpjclwLeK5rVCV2P/uw==",
+      "dev": true,
+      "dependencies": {
+        "lodash.castarray": "^4.4.0",
+        "lodash.isplainobject": "^4.0.6",
+        "lodash.merge": "^4.6.2",
+        "postcss-selector-parser": "6.0.10"
+      },
+      "peerDependencies": {
+        "tailwindcss": ">=3.0.0 || insiders"
+      }
+    },
+    "node_modules/@tailwindcss/typography/node_modules/postcss-selector-parser": {
+      "version": "6.0.10",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
+      "integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
+      "dev": true,
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/@tanstack/query-core": {
@@ -3414,6 +3443,18 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash.castarray": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/lodash.castarray/-/lodash.castarray-4.4.0.tgz",
+      "integrity": "sha512-aVx8ztPv7/2ULbArGJ2Y42bG1mEQ5mGjpdvrbJcJFU3TbYybe+QlLS4pst9zV52ymy2in1KpFPiZnAOATxD4+Q==",
+      "dev": true
+    },
+    "node_modules/lodash.isplainobject": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+      "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+      "dev": true
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "showdown": "^2.1.0"
   },
   "devDependencies": {
+    "@tailwindcss/typography": "^0.5.13",
     "@types/node": "^20",
     "@types/react": "18.2.42",
     "@types/react-dom": "^18",

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -17,5 +17,6 @@ const config: Config = {
   ],
   darkMode: theme.darkMode as Config["darkMode"],
   theme: theme.theme,
+  plugins: [require("@tailwindcss/typography")],
 };
 export default withMT(config);


### PR DESCRIPTION
While the markdown was being correctly rendered into HTML, the Tailwind Preflight styles meant it all just looked like regular text. Tailwind's Typography plugin has a utility class that will add "normal" typography styles.