### PR TITLE
feat: pre-populate form fields with installer input values 

### DIFF
--- a/app/[installer-slug]/[install-id]/page.tsx
+++ b/app/[installer-slug]/[install-id]/page.tsx
@@ -10,9 +10,12 @@ import { getCloudPlatformRegions } from "@/common";
 
 export default async function Installer({ params, searchParams }) {
   const slug = params?.["installer-slug"];
-  const [app, installer] = await Promise.all([
+  const installId = params?.["install-id"];
+
+  const [app, installer, install] = await Promise.all([
     getAppBySlug(slug),
     getInstaller(),
+    getInstall(installId),
   ]);
   const regions = await getCloudPlatformRegions(app.cloud_platform);
 
@@ -41,8 +44,8 @@ export default async function Installer({ params, searchParams }) {
       <main className="flex-auto" id="steps">
         <InstallStepper
           app={app}
+          existingInstall={install}
           installer={installer}
-          existingInstall={null}
           searchParams={searchParams}
           createInstall={createInstall}
           getInstall={getInstall}

--- a/components/AWSInstallerFormFields.tsx
+++ b/components/AWSInstallerFormFields.tsx
@@ -24,7 +24,8 @@ export const AWSRegionSelect: FC<{
 export const AWSInstallerFormFields: FC<{
   searchParams?: Record<string, string>;
   regions: Array<Object>;
-}> = ({ searchParams = {}, regions }) => {
+  aws_account: any | null;
+}> = ({ searchParams = {}, regions, aws_account }) => {
   return (
     <fieldset className="p-4 w-full">
       <label className="mb-2 flex flex-col flex-auto gap-2">
@@ -32,9 +33,11 @@ export const AWSInstallerFormFields: FC<{
         <input
           className="border bg-inherit rounded px-4 py-1.5 shadow-inner"
           defaultValue={
-            Object.hasOwn(searchParams, "iam_role_arn")
-              ? searchParams?.iam_role_arn
-              : ""
+            aws_account
+              ? aws_account.iam_role_arn
+              : Object.hasOwn(searchParams, "iam_role_arn")
+                ? searchParams?.iam_role_arn
+                : ""
           }
           name="iam_role_arn"
           type="text"
@@ -46,7 +49,11 @@ export const AWSInstallerFormFields: FC<{
         <span className="text-sm font-medium">AWS Region</span>
         <AWSRegionSelect
           defaultValue={
-            Object.hasOwn(searchParams, "region") ? searchParams?.region : ""
+            aws_account
+              ? aws_account.region
+              : Object.hasOwn(searchParams, "region")
+                ? searchParams?.region
+                : ""
           }
           regions={regions}
         />

--- a/components/AzureInstallerFormFields.tsx
+++ b/components/AzureInstallerFormFields.tsx
@@ -24,7 +24,8 @@ export const AzureLocationSelect: FC<{
 export const AzureInstallerFormFields: FC<{
   searchParams?: Record<string, string>;
   regions: Array<Record<string, any>>;
-}> = ({ searchParams = {}, regions }) => {
+  azure_account: any | null;
+}> = ({ searchParams = {}, regions, azure_account }) => {
   return (
     <fieldset className="p-4 w-full">
       <label className="mb-2 flex flex-col flex-auto gap-2">
@@ -44,9 +45,11 @@ export const AzureInstallerFormFields: FC<{
         <input
           className="border bg-inherit rounded px-4 py-1.5 shadow-inner"
           defaultValue={
-            Object.hasOwn(searchParams, "service_principal_app_id")
-              ? searchParams?.service_principal_app_id
-              : ""
+            azure_account
+              ? azure_account.service_principal_app_id
+              : Object.hasOwn(searchParams, "service_principal_app_id")
+                ? searchParams?.service_principal_app_id
+                : ""
           }
           name="service_principal_app_id"
           type="text"
@@ -59,9 +62,11 @@ export const AzureInstallerFormFields: FC<{
         <input
           className="border bg-inherit rounded px-4 py-1.5 shadow-inner"
           defaultValue={
-            Object.hasOwn(searchParams, "service_principal_password")
-              ? searchParams?.service_principal_password
-              : ""
+            azure_account
+              ? azure_account.service_principal_password
+              : Object.hasOwn(searchParams, "service_principal_password")
+                ? searchParams?.service_principal_password
+                : ""
           }
           name="service_principal_password"
           type="password"
@@ -74,9 +79,11 @@ export const AzureInstallerFormFields: FC<{
         <input
           className="border bg-inherit rounded px-4 py-1.5 shadow-inner"
           defaultValue={
-            Object.hasOwn(searchParams, "subscription_id")
-              ? searchParams?.subscription_id
-              : ""
+            azure_account
+              ? azure_account.subscription_id
+              : Object.hasOwn(searchParams, "subscription_id")
+                ? searchParams?.subscription_id
+                : ""
           }
           name="subscription_id"
           type="text"
@@ -89,9 +96,11 @@ export const AzureInstallerFormFields: FC<{
         <input
           className="border bg-inherit rounded px-4 py-1.5 shadow-inner"
           defaultValue={
-            Object.hasOwn(searchParams, "subscription_tenant_id")
-              ? searchParams?.subscription_tenant_id
-              : ""
+            azure_account
+              ? azure_account.subscription_tenant_id
+              : Object.hasOwn(searchParams, "subscription_tenant_id")
+                ? searchParams?.subscription_tenant_id
+                : ""
           }
           name="subscription_tenant_id"
           type="text"

--- a/components/InputFields.tsx
+++ b/components/InputFields.tsx
@@ -3,7 +3,8 @@ import React, { type FC } from "react";
 export const InputFields: FC<{
   group: Record<string, any>;
   searchParams?: Record<string, string>;
-}> = ({ group, searchParams = {} }) => {
+  install_input_values: Object;
+}> = ({ group, searchParams = {}, install_input_values }) => {
   return (
     <fieldset key={group.id} name={group.name} className="p-4 w-full">
       {group.app_inputs.map((input) => (
@@ -14,9 +15,11 @@ export const InputFields: FC<{
           <input
             className="border bg-inherit rounded px-4 py-1.5 shadow-inner"
             defaultValue={
-              Object.hasOwn(searchParams, `input:${input.name}`)
-                ? searchParams?.[`input:${input.name}`]
-                : input?.default
+              Object.keys(install_input_values).includes(input.name)
+                ? install_input_values[input.name]
+                : Object.hasOwn(searchParams, `input:${input.name}`)
+                  ? searchParams?.[`input:${input.name}`]
+                  : input?.default
             }
             name={`input:${input.name}`}
             required={input.required}

--- a/components/InstallStepper/CloudAccountContent.tsx
+++ b/components/InstallStepper/CloudAccountContent.tsx
@@ -9,6 +9,8 @@ import {
 
 export const CloudAccountContent = ({
   app = { cloud_platform: "aws" },
+  aws_account = null,
+  azure_account = null,
   open = false,
   onClick = () => {},
   searchParams = {},
@@ -38,6 +40,7 @@ export const CloudAccountContent = ({
             <AWSInstallerFormFields
               searchParams={searchParams}
               regions={regions}
+              aws_account={aws_account}
             />
           </Card>
         </AccordionBody>
@@ -53,6 +56,7 @@ export const CloudAccountContent = ({
             <AzureInstallerFormFields
               searchParams={searchParams}
               regions={regions}
+              azure_account={azure_account}
             />
           </Card>
         </AccordionBody>

--- a/components/InstallStepper/CompanyContent.tsx
+++ b/components/InstallStepper/CompanyContent.tsx
@@ -5,6 +5,7 @@ export const CompanyContent = ({
   open = false,
   onClick = () => {},
   searchParams = { name: "" },
+  name = null,
 }) => (
   <Accordion open={open}>
     <AccordionHeader
@@ -30,7 +31,11 @@ export const CompanyContent = ({
             <input
               className="border bg-inherit rounded px-4 py-1.5 shadow-inner"
               defaultValue={
-                Object.hasOwn(searchParams, "name") ? searchParams.name : ""
+                name
+                  ? name
+                  : Object.hasOwn(searchParams, "name")
+                    ? searchParams.name
+                    : ""
               }
               name="name"
               type="text"

--- a/components/InstallStepper/GroupContent.tsx
+++ b/components/InstallStepper/GroupContent.tsx
@@ -7,6 +7,7 @@ export const GroupContent = ({
   activeStep = 0,
   setActiveStep = (idx = 0) => {},
   searchParams = {},
+  install_input_values = {},
 }) => (
   <Accordion key={idx} open={activeStep === idx + 2}>
     <AccordionHeader
@@ -27,7 +28,11 @@ export const GroupContent = ({
     </AccordionHeader>
     <AccordionBody>
       <Card>
-        <InputFields group={group} searchParams={searchParams} />
+        <InputFields
+          group={group}
+          install_input_values={install_input_values}
+          searchParams={searchParams}
+        />
       </Card>
     </AccordionBody>
   </Accordion>

--- a/components/InstallStepper/GroupContent.tsx
+++ b/components/InstallStepper/GroupContent.tsx
@@ -1,8 +1,9 @@
 import { Accordion, AccordionHeader, AccordionBody } from "../Accordion";
+import { Markdown } from "@/components/Markdown";
 import { InputFields, Card } from "@/components";
 
 export const GroupContent = ({
-  group = { display_name: "" },
+  group = { display_name: "", description: "" },
   idx = 0,
   activeStep = 0,
   setActiveStep = (idx = 0) => {},
@@ -28,6 +29,9 @@ export const GroupContent = ({
     </AccordionHeader>
     <AccordionBody>
       <Card>
+        <div className="px-4">
+          <Markdown content={group.description}></Markdown>
+        </div>
         <InputFields
           group={group}
           install_input_values={install_input_values}

--- a/components/InstallStepper/InstallStatusContent/InstallButton.tsx
+++ b/components/InstallStepper/InstallStatusContent/InstallButton.tsx
@@ -4,7 +4,8 @@ export const InstallButton = ({ install }) => {
   const loading = install.status === "provisioning";
 
   let label = "Create Install";
-  if (install.id.length > 0) label = "Reprovision Install";
+  if (install && install.id && install.id.length > 0)
+    label = "Reprovision Install";
   if (loading) label = "Provisioning";
 
   return (

--- a/components/InstallStepper/index.tsx
+++ b/components/InstallStepper/index.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import React, { useEffect, useRef } from "react";
+import { useRouter } from "next/navigation";
+
 import { Stepper, Step } from "../Stepper";
 import { Typography } from "@material-tailwind/react";
 
@@ -13,6 +15,7 @@ import { ErrorAlert } from "./ErrorAlert";
 
 const InstallStepper = ({
   app,
+  existingInstall,
   installer,
   searchParams,
   regions,
@@ -20,20 +23,28 @@ const InstallStepper = ({
   getInstall,
   redeployInstall,
 }) => {
-  const [activeStep, setActiveStep] = React.useState(0);
+  const [activeStep, setActiveStep] = React.useState(
+    existingInstall ? app.input_config.input_groups.length + 2 : 0,
+  );
   const [isLastStep, setIsLastStep] = React.useState(false);
   const [isFirstStep, setIsFirstStep] = React.useState(false);
 
   const handleNext = () => !isLastStep && setActiveStep((cur) => cur + 1);
   const handlePrev = () => !isFirstStep && setActiveStep((cur) => cur - 1);
+  const router = useRouter();
 
   // track state of install
-  const [install, setInstall] = React.useState({
-    id: searchParams.install_id || "",
-    status: "not created",
-    status_description: "install has not been created yet",
-    install_components: [],
-  });
+  const [install, setInstall] = React.useState(
+    existingInstall
+      ? existingInstall
+      : {
+          id: searchParams.install_id || "",
+          status: "not created",
+          status_description: "install has not been created yet",
+          install_components: [],
+        },
+  );
+
   const [error, setError] = React.useState({
     description: "",
     error: "",
@@ -54,6 +65,8 @@ const InstallStepper = ({
         return;
       }
       installID = res.id;
+      // navigate to the sub-route
+      router.push(`/${app.name}/${res.id}`);
     } else {
       // if we've already created the install, redeploy it
       const reproRes = await redeployInstall(install.id, app, formData);
@@ -72,6 +85,7 @@ const InstallStepper = ({
     }
 
     setInstall(res);
+
     setError({
       description: "",
       error: "",
@@ -117,11 +131,15 @@ const InstallStepper = ({
     }
   }, 1000 * 10);
 
+  // TODO: break this out into a testable function
+  const _install_inputs = install.install_inputs || [{ values: {} }];
+  const install_input_values = _install_inputs[0].values;
   const input_groups = app.input_config.input_groups || [];
   const stepContent = input_groups.map((group, idx) => (
     <GroupContent
       key={idx}
       group={group}
+      install_input_values={install_input_values}
       idx={idx}
       setActiveStep={() => setActiveStep(idx + 2)}
       activeStep={activeStep}
@@ -209,12 +227,15 @@ const InstallStepper = ({
 
       <form className="mt-10" onSubmit={formAction}>
         <CompanyContent
+          name={install.name}
           open={activeStep === 0}
           onClick={() => setActiveStep(0)}
         />
 
         <CloudAccountContent
           app={app}
+          aws_account={install.aws_account}
+          azure_account={install.aws_account}
           open={activeStep == 1}
           onClick={() => setActiveStep(1)}
           searchParams={searchParams}

--- a/components/InstallStepper/index.tsx
+++ b/components/InstallStepper/index.tsx
@@ -177,7 +177,7 @@ const InstallStepper = ({
         isLastStep={(value) => setIsLastStep(value)}
         isFirstStep={(value) => setIsFirstStep(value)}
         lineClassName="bg-black dark:bg-white"
-        activeLineClassName="!bg-primary-500"
+        activeLineClassName="!bg-step-complete-border-color"
       >
         <Step
           className="border-4 border-black bg-black text-white dark:border-white dark:bg-white dark:text-black"

--- a/theme.ts.example
+++ b/theme.ts.example
@@ -4,7 +4,8 @@ import { generateColorRange } from "./common/generateColors";
 const primary = generateColorRange("#4E17FF");
 
 export default {
-  darkMode: ["media", ["@media (prefers-color-scheme: dark)", "&:is(.dark *)"]],
+  darkMode: ["selector"],
+  // darkMode: [["media", ["@media (prefers-color-scheme: dark)", "&:is(.dark *)"],
   forceDarkMode: true,
   theme: {
     extend: {


### PR DESCRIPTION
### Description 

Allow for editing of existing installs. 
1. add a new view under the `[installer-slug]` path, `[install-id]`.
   this view/page fetches the install and passes it down to the children
   so the current data is available for editing.
2. modify the `InstallStepper` to accept the `install` object.

### Notes

1. We are not wedded to the idea of having this be a separate view. This approach just simplifies routing and reduces the amt. of necessary logic in `[installer-slug]/page.tsx`. 
2. The logic for finding and mapping fields from input_groups to form fields depends on the (correct) assumption an input name must be unique. This is enforced in the API at the db level w/ a uniqueness constraint. https://github.com/powertoolsdev/mono/pull/5155

### Addresses: 

- https://github.com/powertoolsdev/mono/issues/5174
- https://github.com/powertoolsdev/mono/issues/5175

Tagalongs

- https://github.com/powertoolsdev/mono/issues/5166