### PR TITLE
feat: support dark mode

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -5,6 +5,7 @@ import { getInstaller } from "@/common";
 import { Link, PoweredByNuon } from "@/components";
 import { Markdown } from "@/components/Markdown";
 import "./globals.css";
+import theme from "@/theme";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -53,7 +54,7 @@ export default async function RootLayout({
 
   return (
     <html
-      className="bg-page-background text-black dark:bg-black dark:text-white"
+      className={`${theme.forceDarkMode ? "dark" : ""} bg-white dark:bg-black text-black dark:text-white`}
       lang="en"
     >
       <body className={`${inter.className} w-full h-dvh`}>

--- a/components/Accordion.tsx
+++ b/components/Accordion.tsx
@@ -1,48 +1,36 @@
 import React, { type FC } from "react";
+import {
+  Accordion as MTAccordion,
+  AccordionHeader as MTAccordionHeader,
+  AccordionBody as MTAccordionBody,
+} from "@material-tailwind/react";
 
-interface IAccordion extends React.HTMLAttributes<HTMLDivElement> {
-  children: React.ReactNode;
-}
-
-export const Accordion: FC<IAccordion> = ({
-  className = "",
-  children,
-  ...props
-}) => {
+export const Accordion = ({ children, className = "", open, ...props }) => {
   return (
-    <div className={`w-full overflow-hidden ${className}`} {...props}>
+    <MTAccordion className={`${className}`} open={open} {...props}>
       {children}
-    </div>
+    </MTAccordion>
   );
 };
 
-interface ITab extends React.HTMLAttributes<HTMLDivElement> {
-  label: string;
-  children: React.ReactNode;
-}
-
-export const Tab: FC<ITab> = ({
-  label = "",
-  className = "",
-  children,
-  ...props
-}) => {
+export const AccordionHeader = ({ children, className = "", ...props }) => {
   return (
-    <div className={`${className}`} {...props}>
-      <input
-        id={label}
-        type="checkbox"
-        className="peer absolute opacity-0 -z-1"
-      ></input>
-      <label
-        htmlFor={label}
-        className="flex cursor-pointer justify-between p-4 font-medium bg-accordion-header-background text-accordion-header-color after:content-['\276F'] after:w-4 after:h-4 after:text-center after:rotate-90 after:transition-all peer-checked:after:rotate-270"
-      >
-        {label}
-      </label>
-      <div className="max-h-0 overflow-hidden transition-all peer-checked:max-h-max">
-        {children}
-      </div>
-    </div>
+    <MTAccordionHeader
+      className={`text-black dark:text-white hover:!text-gray-500 ${className}`}
+      {...props}
+    >
+      {children}
+    </MTAccordionHeader>
+  );
+};
+
+export const AccordionBody = ({ children, className = "", ...props }) => {
+  return (
+    <MTAccordionBody
+      className={`text-black dark:text-white ${className}`}
+      {...props}
+    >
+      {children}
+    </MTAccordionBody>
   );
 };

--- a/components/Card.tsx
+++ b/components/Card.tsx
@@ -6,7 +6,7 @@ export const Card: FC<{ children?: React.ReactNode; className?: string }> = ({
 }) => {
   return (
     <div
-      className={`flex flex-col gap-2 bg-card-background dark:bg-white items-start border-card-border-color border-card-border-width rounded-card-radius shadow-card-shadow shadow-card-color ${className}`}
+      className={`flex flex-col gap-2 bg-card-background items-start border-card-border-color border-card-border-width rounded-card-radius shadow-card-shadow shadow-card-color ${className}`}
     >
       {children}
     </div>

--- a/components/InstallStepper/CloudAccountContent.tsx
+++ b/components/InstallStepper/CloudAccountContent.tsx
@@ -1,8 +1,4 @@
-import {
-  Accordion,
-  AccordionHeader,
-  AccordionBody,
-} from "@material-tailwind/react";
+import { Accordion, AccordionHeader, AccordionBody } from "../Accordion";
 import {
   AWSInstallerFormFields,
   AzureInstallerFormFields,
@@ -21,7 +17,12 @@ export const CloudAccountContent = ({
   <Accordion open={open}>
     {app.cloud_platform === "aws" && (
       <>
-        <AccordionHeader onClick={onClick}>AWS IAM Role</AccordionHeader>
+        <AccordionHeader
+          className="text-black dark:text-white hover:!text-gray-500"
+          onClick={onClick}
+        >
+          AWS IAM Role
+        </AccordionHeader>
         <AccordionBody className="grid grid-cols-2 gap-4">
           <StepOneAWS app={app} />
           <Card>

--- a/components/InstallStepper/CompanyContent.tsx
+++ b/components/InstallStepper/CompanyContent.tsx
@@ -1,8 +1,4 @@
-import {
-  Accordion,
-  AccordionHeader,
-  AccordionBody,
-} from "@material-tailwind/react";
+import { Accordion, AccordionHeader, AccordionBody } from "../Accordion";
 import { Card } from "@/components";
 
 export const CompanyContent = ({
@@ -11,8 +7,13 @@ export const CompanyContent = ({
   searchParams = { name: "" },
 }) => (
   <Accordion open={open}>
-    <AccordionHeader onClick={onClick}>Company Info</AccordionHeader>
-    <AccordionBody>
+    <AccordionHeader
+      className="text-black dark:text-white hover:!text-gray-500"
+      onClick={onClick}
+    >
+      Company Info
+    </AccordionHeader>
+    <AccordionBody className="text-black dark:text-white">
       <Card>
         <fieldset className="p-4 w-full">
           <label className="flex flex-col flex-auto gap-2">

--- a/components/InstallStepper/GroupContent.tsx
+++ b/components/InstallStepper/GroupContent.tsx
@@ -1,8 +1,4 @@
-import {
-  Accordion,
-  AccordionHeader,
-  AccordionBody,
-} from "@material-tailwind/react";
+import { Accordion, AccordionHeader, AccordionBody } from "../Accordion";
 import { InputFields, Card } from "@/components";
 
 export const GroupContent = ({
@@ -13,7 +9,10 @@ export const GroupContent = ({
   searchParams = {},
 }) => (
   <Accordion key={idx} open={activeStep === idx + 2}>
-    <AccordionHeader onClick={() => setActiveStep(idx + 2)}>
+    <AccordionHeader
+      className="text-black dark:text-white hover:!text-gray-500"
+      onClick={() => setActiveStep(idx + 2)}
+    >
       {group.display_name}
     </AccordionHeader>
     <AccordionBody>

--- a/components/InstallStepper/InstallStatusContent/index.tsx
+++ b/components/InstallStepper/InstallStatusContent/index.tsx
@@ -1,8 +1,4 @@
-import {
-  Accordion,
-  AccordionHeader,
-  AccordionBody,
-} from "@material-tailwind/react";
+import { Accordion, AccordionHeader, AccordionBody } from "../../Accordion";
 import { InstallStatus } from "./InstallStatus";
 import { StatusIcon } from "@/components";
 import { InstallButton } from "./InstallButton";
@@ -18,7 +14,10 @@ export const InstallStatusContent = ({
   post_install_markdown = "",
 }) => (
   <Accordion open={open}>
-    <AccordionHeader onClick={onClick}>
+    <AccordionHeader
+      className="text-black dark:text-white hover:!text-gray-500"
+      onClick={onClick}
+    >
       <span>
         Install Status <StatusIcon status={install.status} />{" "}
         <span className="text-sm font-medium">

--- a/components/InstallStepper/NavArrows.tsx
+++ b/components/InstallStepper/NavArrows.tsx
@@ -8,7 +8,7 @@ export const NavArrows = ({
 }) => (
   <div className="absolute -left-8 -right-8 top-1/2 flex justify-between">
     <IconButton
-      className="rounded-full"
+      className="rounded-full bg-black dark:bg-white text-white dark:text-black"
       onClick={handlePrev}
       disabled={isFirstStep}
     >
@@ -28,7 +28,7 @@ export const NavArrows = ({
       </svg>
     </IconButton>
     <IconButton
-      className="rounded-full"
+      className="rounded-full bg-black dark:bg-white text-white dark:text-black"
       onClick={handleNext}
       disabled={isLastStep}
     >

--- a/components/InstallStepper/index.tsx
+++ b/components/InstallStepper/index.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useEffect, useRef } from "react";
-import { Stepper, Step } from "@material-tailwind/react";
+import { Stepper, Step } from "../Stepper";
 
 import { NavArrows } from "./NavArrows";
 import { CompanyContent } from "./CompanyContent";
@@ -128,7 +128,13 @@ const InstallStepper = ({
   ));
 
   const steps = input_groups.map((group, idx) => (
-    <Step key={idx} onClick={() => setActiveStep(idx + 2)}>
+    <Step
+      className="bg-black text-white dark:bg-white dark:text-black"
+      activeClassName="!bg-primary-500"
+      completedClassName="!bg-primary-500"
+      key={idx}
+      onClick={() => setActiveStep(idx + 2)}
+    >
       {idx + 3}
     </Step>
   ));
@@ -146,14 +152,35 @@ const InstallStepper = ({
         activeStep={activeStep}
         isLastStep={(value) => setIsLastStep(value)}
         isFirstStep={(value) => setIsFirstStep(value)}
+        lineClassName="bg-black dark:bg-white"
+        activeLineClassName="!bg-primary-500"
       >
-        <Step onClick={() => setActiveStep(0)}>1</Step>
+        <Step
+          className="bg-black text-white dark:bg-white dark:text-black"
+          activeClassName="!bg-primary-500"
+          completedClassName="!bg-primary-500"
+          onClick={() => setActiveStep(0)}
+        >
+          1
+        </Step>
 
-        <Step onClick={() => setActiveStep(1)}>2</Step>
+        <Step
+          className="bg-black text-white dark:bg-white dark:text-black"
+          activeClassName="!bg-primary-500"
+          completedClassName="!bg-primary-500"
+          onClick={() => setActiveStep(1)}
+        >
+          2
+        </Step>
 
         {...steps}
 
-        <Step onClick={() => setActiveStep(steps.length + 2)}>
+        <Step
+          className="bg-black text-white dark:bg-white dark:text-black"
+          activeClassName="!bg-primary-500"
+          completedClassName="!bg-primary-500"
+          onClick={() => setActiveStep(steps.length + 2)}
+        >
           {steps.length + 3}
         </Step>
       </Stepper>

--- a/components/Markdown.tsx
+++ b/components/Markdown.tsx
@@ -3,7 +3,7 @@ const markdown = new showdown.Converter();
 
 export const Markdown = ({ content = "" }) => (
   <div
-    className="prose"
+    className="prose dark:prose-invert"
     dangerouslySetInnerHTML={{
       __html: markdown.makeHtml(content),
     }}

--- a/components/Stepper.tsx
+++ b/components/Stepper.tsx
@@ -1,0 +1,27 @@
+import React, { type FC } from "react";
+import { Stepper as MTStepper, Step as MTStep } from "@material-tailwind/react";
+
+export const Stepper = ({ children, ...props }) => {
+  return (
+    <MTStepper
+      lineClassName="bg-black dark:bg-white"
+      activeLineClassName="!bg-primary-500"
+      {...props}
+    >
+      {children}
+    </MTStepper>
+  );
+};
+
+export const Step = ({ children, ...props }) => {
+  return (
+    <MTStep
+      className="bg-black text-white dark:bg-white dark:text-black"
+      activeClassName="!bg-primary-500"
+      completedClassName="!bg-primary-500"
+      {...props}
+    >
+      {children}
+    </MTStep>
+  );
+};

--- a/theme.ts.example
+++ b/theme.ts.example
@@ -5,17 +5,18 @@ const primary = generateColorRange("#4E17FF");
 
 export default {
   darkMode: "selector",
+  forceDarkMode: true,
   theme: {
     extend: {
       colors: {
         black: colors.black,
         white: colors.white,
         primary: primary,
-        "page-background": colors.white,
+        "card-text-color": colors.white,
         "card-border-color": colors.black,
-        "card-background": colors.white,
+        "card-background": "rgb(255 255 255 / 5%)",
         "accordion-header-color": colors.black,
-        "accordion-header-background": colors.gray["100"],
+        "accordion-header-background": primary["500"],
         "button-text-color": colors.gray["50"],
         "button-border-color": colors.black,
         "button-bg-color": primary["500"],


### PR DESCRIPTION
These changes attempt to support dark mode, while still allowing custom theme settings.

Dark mode support has been on my mind for a while now, but so far we haven't had a vendor whose branding required it. ParadeDB is now that vendor.

While it was technically possible to get a similar result using just the custom theme settings, enabling dark mode ensures all content will work on the dark page background. This includes the HTML being dynamically generated from the markdown fields.

Now we should be able to easily support dark themes for ParadeDB and future vendors, without any customization.