### PR TITLE
feat(markdown): open markdown links in new tabs

### DIFF
--- a/components/Markdown.tsx
+++ b/components/Markdown.tsx
@@ -1,5 +1,18 @@
 import showdown from "showdown";
-const markdown = new showdown.Converter();
+
+// load extension to add target="_blank" to links
+showdown.extension("targetlink", () => {
+  return [
+    {
+      type: "html",
+      regex: /(<a [^>]+?)(>.*<\/a>)/g,
+      replace: '$1 target="_blank"$2',
+    },
+  ];
+});
+
+// instantiate converter
+const markdown = new showdown.Converter({ extensions: ["targetlink"] });
 
 export const Markdown = ({ content = "" }) => (
   <div


### PR DESCRIPTION
### Description 

links in user-provided markdown content should be opened in a new tab. we achieve this by creating an extension for the showdown markdown rendering library, `targetlinks`.

Source: https://github.com/showdownjs/showdown/issues/337

### Addresses

- https://github.com/powertoolsdev/mono/issues/5180