### PR TITLE
 feat: interpolate install.install_inputs.values into the post_install_markdown

### DIFF
--- a/app/[installer-slug]/actions.ts
+++ b/app/[installer-slug]/actions.ts
@@ -125,7 +125,7 @@ export async function redeployInstall(
     return updateRes;
   }
 
-  if (reqBody.inputs.length > 0) {
+  if (Object.keys(reqBody.inputs).length > 0) {
     const inputsRes = await updateInputs(id, app, formData);
     if (inputsRes.error) {
       return inputsRes;

--- a/components/InstallStepper/InstallStatusContent/InstallButton.tsx
+++ b/components/InstallStepper/InstallStatusContent/InstallButton.tsx
@@ -4,9 +4,12 @@ export const InstallButton = ({ install }) => {
   const loading = install.status === "provisioning";
 
   let label = "Create Install";
-  if (install && install.id && install.id.length > 0)
+  if (install && install.id && install.id.length > 0) {
     label = "Reprovision Install";
-  if (loading) label = "Provisioning";
+  }
+  if (loading) {
+    label = "Provisioning";
+  }
 
   return (
     <Button

--- a/components/InstallStepper/InstallStatusContent/index.tsx
+++ b/components/InstallStepper/InstallStatusContent/index.tsx
@@ -4,7 +4,7 @@ import { StatusIcon } from "@/components";
 import { InstallButton } from "./InstallButton";
 import { Markdown } from "@/components/Markdown";
 
-const interpolateInputs = (inputs: {}, text) => {
+const interpolateInputsAndInstallId = (install_id, inputs: {}, text) => {
   let interpolated = text;
   Object.keys(inputs).forEach((key) => {
     let value = inputs[key];
@@ -14,6 +14,16 @@ const interpolateInputs = (inputs: {}, text) => {
     ); // https://regex101.com/r/U5iEei/1
     interpolated = interpolated.replaceAll(regex, value);
   });
+
+  if (install_id) {
+    // interpolate install.id
+    let regex = new RegExp(
+      String.raw`\{\{[ ]{0,1}\.nuon\.install\.id[ ]{0,1}\}\}`,
+      "g",
+    ); // https://regex101.com/r/U5iEei/1
+    interpolated = interpolated.replaceAll(regex, install_id);
+  }
+
   return interpolated;
 };
 
@@ -21,6 +31,7 @@ export const InstallStatusContent = ({
   open = false,
   onClick = () => {},
   install = {
+    id: null,
     status: "",
     status_description: "",
     install_inputs: [],
@@ -32,7 +43,8 @@ export const InstallStatusContent = ({
     install_input_values =
       install.install_inputs[install.install_inputs.length - 1].values;
   }
-  const post_install_markdown_with_inputs = interpolateInputs(
+  const post_install_markdown_with_inputs = interpolateInputsAndInstallId(
+    install.id,
     install_input_values,
     post_install_markdown,
   );

--- a/components/InstallStepper/InstallStatusContent/index.tsx
+++ b/components/InstallStepper/InstallStatusContent/index.tsx
@@ -4,49 +4,74 @@ import { StatusIcon } from "@/components";
 import { InstallButton } from "./InstallButton";
 import { Markdown } from "@/components/Markdown";
 
+const interpolateInputs = (inputs: {}, text) => {
+  let interpolated = text;
+  Object.keys(inputs).forEach((key) => {
+    let value = inputs[key];
+    let regex = new RegExp(
+      String.raw`\{\{[ ]{0,1}\.nuon\.install\.inputs\.${key}[ ]{0,1}\}\}`,
+      "g",
+    ); // https://regex101.com/r/U5iEei/1
+    interpolated = interpolated.replaceAll(regex, value);
+  });
+  return interpolated;
+};
+
 export const InstallStatusContent = ({
   open = false,
   onClick = () => {},
   install = {
     status: "",
     status_description: "",
+    install_inputs: [],
   },
   post_install_markdown = "",
-}) => (
-  <Accordion open={open}>
-    <AccordionHeader
-      className={
-        open
-          ? `px-4
+}) => {
+  let install_input_values = {};
+  if (install.install_inputs && install.install_inputs.length > 0) {
+    install_input_values =
+      install.install_inputs[install.install_inputs.length - 1].values;
+  }
+  const post_install_markdown_with_inputs = interpolateInputs(
+    install_input_values,
+    post_install_markdown,
+  );
+  return (
+    <Accordion open={open}>
+      <AccordionHeader
+        className={
+          open
+            ? `px-4
               text-accordion-header-active-color
               dark:text-accordion-header-active-color-dark
               hover:!text-gray-500
               bg-accordion-header-active-background
               dark:bg-accordion-header-active-background-dark`
-          : "px-4"
-      }
-      onClick={onClick}
-    >
-      <span>
-        Install Status <StatusIcon status={install.status} />{" "}
-        <span className="text-sm font-medium">
-          {install.status_description}
+            : "px-4"
+        }
+        onClick={onClick}
+      >
+        <span>
+          Install Status <StatusIcon status={install.status} />{" "}
+          <span className="text-sm font-medium">
+            {install.status_description}
+          </span>
         </span>
-      </span>
-    </AccordionHeader>
-    <AccordionBody>
-      <div className="grid grid-cols-2 gap-2">
-        <div>
-          <Markdown content={post_install_markdown} />
-        </div>
+      </AccordionHeader>
+      <AccordionBody>
+        <div className="grid grid-cols-2 gap-2">
+          <div>
+            <Markdown content={post_install_markdown_with_inputs} />
+          </div>
 
-        <div>
-          <InstallStatus install={install} />
-          <div className="mt-4 flex justify-end">
-            <InstallButton install={install} />
+          <div>
+            <InstallStatus install={install} />
+            <div className="mt-4 flex justify-end">
+              <InstallButton install={install} />
+            </div>
           </div>
         </div>
-      </div>
-    </AccordionBody>
-  </Accordion>
-);
+      </AccordionBody>
+    </Accordion>
+  );
+};

--- a/components/InstallStepper/index.tsx
+++ b/components/InstallStepper/index.tsx
@@ -55,6 +55,11 @@ const InstallStepper = ({
   const formAction = async (event) => {
     event.preventDefault();
 
+    if (event.key == "Enter") {
+      // this should have been caught by onKeyUp but we include it here also
+      handleNext();
+    }
+
     const formData = new FormData(event.target);
     let installID = "";
     if (install.id === "") {
@@ -225,7 +230,16 @@ const InstallStepper = ({
         </Step>
       </Stepper>
 
-      <form className="mt-10" onSubmit={formAction}>
+      <form
+        className="mt-10"
+        onSubmit={formAction}
+        onKeyUp={(e) => {
+          e.preventDefault();
+          if (e.key == "Enter") {
+            handleNext();
+          }
+        }}
+      >
         <CompanyContent
           name={install.name}
           open={activeStep === 0}


### PR DESCRIPTION
### Description

Introduces a rather hamfisted method to interpolate values from `input_values` into the `post_install_markdown`. 

Also fixes a bug that was preventing inputs from being updated on the install. 


Addresses: https://github.com/orgs/powertoolsdev/projects/16/views/18?pane=issue&itemId=69418130