### PR TITLE
Fd/fix rendering of large logos

### DIFF
--- a/app/[installer-slug]/page.tsx
+++ b/app/[installer-slug]/page.tsx
@@ -19,13 +19,13 @@ export default async function Installer({ params, searchParams }) {
   return (
     <>
       <header className="flex flex-col gap-4">
-        <div className="flex justify-between items-center pt-4">
+        <div className="flex justify-between items-center pt-4 pb-4">
           <Link className="w-fit" href="/">
             {"< Other installation options"}
           </Link>
           <Link href={installer?.metadata?.homepage_url}>
             <img
-              className="inline-block"
+              className="inline-block min-h-16 max-w-2xl"
               src={installer?.metadata?.logo_url}
               alt={installer?.metadata?.name}
             />

--- a/theme.ts.example
+++ b/theme.ts.example
@@ -38,8 +38,8 @@ export default {
         // card shadow classes are applied not applied by default. only on landing page cards.
         "card-shadow": "4px 4px 0 0 black, 0 1px 2px -1px black",
         "card-shadow-dark": "4px 4px 0 0 white, 0 1px 2px -1px white",
-        "button-shadow":
-          "0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1)",
+        "button-shadow": "3px 3px 0 0 black, 0 1px 2px -1px black",
+        "button-shadow-dark": "3px 3px 0 0 white, 0 1px 2px -1px white",
       },
       borderWidth: {
         "card-border-width": "1px",


### PR DESCRIPTION
Ensure large logos don't "overflow" and hide. 


### Note

impacts the way all logos are rendered
