### PR TITLE
feat: delegation aware installer 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+.env
+.env.local
+.env.stage
+
 # See https://help.github.com/articles/ignoring-files/ for more about ignoring files.
 
 # dependencies

--- a/components/AWSInstallerFormFields.tsx
+++ b/components/AWSInstallerFormFields.tsx
@@ -25,6 +25,7 @@ export const AWSInstallerFormFields: FC<{
   searchParams?: Record<string, string>;
   regions: Array<Object>;
   aws_account: any | null;
+  aws_delegation_config: { iam_role_arn: "" } | null;
 }> = ({ searchParams = {}, regions, aws_account }) => {
   return (
     <fieldset className="p-4 w-full">

--- a/components/InstallStepper/CloudAccountContent.tsx
+++ b/components/InstallStepper/CloudAccountContent.tsx
@@ -7,8 +7,18 @@ import {
   Card,
 } from "@/components";
 
+interface AWSDelegationConfig {
+  iam_role_arn: string | null;
+}
+interface SandboxConfig {
+  aws_delegation_config: AWSDelegationConfig;
+}
+
 export const CloudAccountContent = ({
-  app = { cloud_platform: "aws" },
+  app = {
+    cloud_platform: "aws",
+    sandbox_config: { aws_delegation_config: { iam_role_arn: null } },
+  },
   aws_account = null,
   azure_account = null,
   open = false,
@@ -38,6 +48,7 @@ export const CloudAccountContent = ({
           <StepOneAWS app={app} />
           <Card>
             <AWSInstallerFormFields
+              aws_delegation_config={app?.sandbox_config?.aws_delegation_config}
               searchParams={searchParams}
               regions={regions}
               aws_account={aws_account}

--- a/components/StepOneAWS.tsx
+++ b/components/StepOneAWS.tsx
@@ -1,7 +1,47 @@
 import React, { type FC } from "react";
 import { Link, Card } from "@/components";
 
+/*
+ * Compose the Cloud Formation QuickCreate URL
+ *
+ * The templateUrl changes based on wether or not delegation is enabled.
+ *
+ */
+const composeCloudformationQuickCreateUrl = (app, aws_delegation_config) => {
+  const base_url =
+    "https://us-west-2.console.aws.amazon.com/cloudformation/home#/stacks/quickcreate";
+
+  let delegationEnabled =
+    aws_delegation_config && aws_delegation_config.iam_role_arn;
+  let params = {};
+
+  if (delegationEnabled) {
+    params = {
+      templateUrl:
+        "https://nuon-artifacts.s3.us-west-2.amazonaws.com/sandbox/aws-ecs/cloudformation-template.yaml",
+      stackName: `nuon-${app?.sandbox_config?.public_git_vcs_config?.directory}-permissions`,
+      param_DelegationRoleARN: `${aws_delegation_config?.iam_role_arn}`,
+    };
+  } else {
+    params = {
+      templateUrl:
+        app?.sandbox_config?.artifacts?.cloudformation_stack_template,
+      stackName: `nuon-${app?.sandbox_config?.public_git_vcs_config?.directory}-permissions`,
+      param_DelegationRoleARN: `${aws_delegation_config?.iam_role_arn}`,
+    };
+  }
+
+  let searchParams = new URLSearchParams(params);
+  let url = new URL(base_url);
+  return url + "?" + searchParams.toString();
+};
+
 export const StepOneAWS: FC<{ app: Record<string, any> }> = ({ app }) => {
+  let aws_delegation_config = app?.sandbox_config?.aws_delegation_config;
+  let quickCreateUrl = composeCloudformationQuickCreateUrl(
+    app,
+    aws_delegation_config,
+  );
   return (
     <div className="flex flex-col gap-4">
       <p>
@@ -40,7 +80,7 @@ export const StepOneAWS: FC<{ app: Record<string, any> }> = ({ app }) => {
 
         <Link
           className="text-sm mt-4"
-          href={`https://us-west-2.console.aws.amazon.com/cloudformation/home#/stacks/quickcreate?templateUrl=${app?.sandbox_config?.artifacts?.cloudformation_stack_template}&stackName=nuon-${app?.sandbox_config?.public_git_vcs_config?.directory}-permissions`}
+          href={quickCreateUrl}
           target="_blank"
           rel="noreferrer"
         >


### PR DESCRIPTION
## feat: delegation aware installer 

only works for AWS. is backwards compatible. 

The future looks like it will be "delegation first" or "delegation-only" so we can expect to simplify this as that change is rolled out. 