### PR TITLE
feat: install status: interpolate sandbox outputs

### DIFF
--- a/app/[installer-slug]/actions.ts
+++ b/app/[installer-slug]/actions.ts
@@ -22,6 +22,29 @@ export async function createInstall(
   return await res.json();
 }
 
+async function getLatestInstallSandboxRunOutputs(
+  id: string,
+): Promise<Record<string, any>> {
+  const res = await fetch(`${NUON_API_URL}/v1/installs/${id}/sandbox-runs`, {
+    cache: "no-store",
+    headers: {
+      Authorization: `Bearer ${process?.env?.NUON_API_TOKEN}`,
+      "X-Nuon-Org-ID": process.env?.NUON_ORG_ID || "",
+    },
+  });
+
+  // work-around for API bug
+  let json = await res.json();
+  if (Array.isArray(json) && json.length > 0) {
+    json = json[0]; // TODO(fd): find out if this needs to be first or last
+  }
+  if (json.runner_job && json.runner_job.outputs) {
+    return json.runner_job.outputs;
+  }
+  return {};
+}
+
+// get install but also get the sandbox outputs
 export async function getInstall(id: string): Promise<Record<string, any>> {
   const res = await fetch(`${NUON_API_URL}/v1/installs/${id}`, {
     cache: "no-store",
@@ -36,6 +59,12 @@ export async function getInstall(id: string): Promise<Record<string, any>> {
   if (Array.isArray(json)) {
     json = json[0];
   }
+
+  // get sandbox outputs
+  // NOTE(fd): this is hacky - consider not doing this
+  let sandbox_outputs = await getLatestInstallSandboxRunOutputs(id);
+  json["sandbox"] = {};
+  json["sandbox"]["outputs"] = sandbox_outputs;
 
   return json;
 }

--- a/components/InstallStepper/InstallStatusContent/index.tsx
+++ b/components/InstallStepper/InstallStatusContent/index.tsx
@@ -1,10 +1,27 @@
 import { Accordion, AccordionHeader, AccordionBody } from "../../Accordion";
 import { InstallStatus } from "./InstallStatus";
-import { StatusIcon } from "@/components";
 import { InstallButton } from "./InstallButton";
 import { Markdown } from "@/components/Markdown";
 
-const interpolateInputsAndInstallId = (install_id, inputs: {}, text) => {
+function flattenSandboxOutputs(obj: object, suffix: string, ans: object) {
+  for (var x in obj) {
+    var key: string;
+    if (suffix != "") key = suffix + "." + x;
+    else key = x;
+    if (typeof obj[x] === "object") {
+      flattenSandboxOutputs(obj[x], key, ans);
+    } else {
+      ans[key] = obj[x];
+    }
+  }
+}
+
+const interpolateInputsAndInstallId = (
+  install_id: string,
+  inputs: {},
+  sandbox_outputs: {},
+  text: string,
+) => {
   let interpolated = text;
   Object.keys(inputs).forEach((key) => {
     let value = inputs[key];
@@ -24,6 +41,18 @@ const interpolateInputsAndInstallId = (install_id, inputs: {}, text) => {
     interpolated = interpolated.replaceAll(regex, install_id);
   }
 
+  // flatten the sandbox_output keys so we can use this simple regex matching
+  let flatSandboxOutputs = {};
+  flattenSandboxOutputs(sandbox_outputs, "", flatSandboxOutputs);
+  Object.keys(flatSandboxOutputs).forEach((key) => {
+    let value = flatSandboxOutputs[key];
+    let regex = new RegExp(
+      String.raw`\{\{[ ]{0,1}\.nuon\.install\.sandbox\.outputs\.${key}[ ]{0,1}\}\}`,
+      "g",
+    ); // https://regex101.com/r/U5iEei/1
+    interpolated = interpolated.replaceAll(regex, value);
+  });
+
   return interpolated;
 };
 
@@ -35,6 +64,7 @@ export const InstallStatusContent = ({
     status: "",
     status_description: "",
     install_inputs: [],
+    sandbox: { outputs: {} },
   },
   post_install_markdown = "",
 }) => {
@@ -46,6 +76,7 @@ export const InstallStatusContent = ({
   const post_install_markdown_with_inputs = interpolateInputsAndInstallId(
     install.id,
     install_input_values,
+    install.sandbox.outputs,
     post_install_markdown,
   );
   return (


### PR DESCRIPTION
### Description

we were previously only interpolating install inputs. we adopt a similar approach for install sandbox outputs. 

### Notes

I don't _love_ this, but were: 
1. fetching the latest sandbox run outputs when we fetch and install; and
2. adding `sandbox.outputs` to the install directly; then
3. flattening the list of outputs so we can use a singular "key" in our regex and interpolating them w/ a regex. 

I mean, it _works_ but i think we can solve this on the API side at a future date. 